### PR TITLE
Updated HaPy cabal file, to work with ghc 7.6.3 and base >= 4.5

### DIFF
--- a/haskell/HaPy.cabal
+++ b/haskell/HaPy.cabal
@@ -17,4 +17,4 @@ library
   other-modules:
       Foreign.HaPy.Internal
   extensions: TemplateHaskell
-  build-depends:       base ==4.5.*, th-lift ==0.5.5, template-haskell >=2.7.0.0
+  build-depends:       base >=4.5, th-lift ==0.5.5, template-haskell >=2.7.0.0


### PR DESCRIPTION
Updated HaPy cabal file, to work with ghc 7.6.3 and base >= 4.5
