### PR TITLE
changing bounds on base in .cabal to work with ghc 7.10

### DIFF
--- a/HaPy-haskell/HaPy.cabal
+++ b/HaPy-haskell/HaPy.cabal
@@ -12,10 +12,12 @@ build-type:          Simple
 cabal-version:       >=1.8
 
 library
-  exposed-modules:     
+  exposed-modules:
       Foreign.HaPy
   other-modules:
       Foreign.HaPy.Internal
   extensions: TemplateHaskell
   c-sources:           HaPy_init.c
-  build-depends:       base >=4.5 && < 4.8, th-lift ==0.5.*, template-haskell >=2.7.0.0
+  build-depends:       base >=4.5,
+                       th-lift >=0.5,
+                       template-haskell >=2.7.0.0


### PR DESCRIPTION
ghc 7.10 uses `base 4.8`, so I had to update the base dep. bounds. Works for me with ghc 7.8 and 7.10.

Is there are reason why you required a particular major version of `th-lift` before?

Another thing I had to do to get `HaPy` working with ghc 7.10 is issue the following install command:

`cabal install --enable-shared --enable-executable-dynamic`

Haven't thought about why this is necessary for me.
